### PR TITLE
Feat/server-creation-and-home

### DIFF
--- a/actions/createServer.ts
+++ b/actions/createServer.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import {
+  createServerConfig,
+  createServerEntry,
+  createServerMember,
+} from "../prisma/services/serverService";
+import * as bcrypt from "bcryptjs";
+
+type newServerData = {
+  serverName: string;
+  description?: string;
+  image?: string;
+  isProtected?: boolean;
+  password?: string;
+  explorePermission?: boolean;
+  searchPermission?: boolean;
+  settingsRightsHolders: string;
+};
+
+export default async function createServer(
+  user_id: string,
+  data: newServerData,
+) {
+  if (data.isProtected && data.password === "") {
+    return "Server is set to protected but no password was given.";
+  }
+
+  try {
+    const server = await createServerEntry({
+      server_name: data.serverName,
+      description: data.description,
+    });
+    if (typeof server === "string")
+      return "Something went wrong. Please try again.";
+
+    const password_hash = await bcrypt.hash(String(data.password), 10);
+
+    const serverConfig = await createServerConfig({
+      server_id: server.id,
+      config_permission: data.settingsRightsHolders,
+      protected: data.isProtected,
+      password_hash: data.isProtected ? password_hash : undefined,
+      explorable: data.explorePermission,
+      searchable: data.searchPermission,
+    });
+
+    if (typeof serverConfig === "string")
+      return "Something went wrong while setting up the server.";
+
+    const serverOwner = await createServerMember({
+      server_id: server.id,
+      member_id: user_id,
+      role: "admin",
+    });
+
+    if (typeof serverOwner === "string")
+      return "Something went wrong while setting up the server.";
+
+    return server;
+  } catch (e) {
+    return (e as Error).message;
+  }
+}

--- a/app/_components/ProfilePicture.tsx
+++ b/app/_components/ProfilePicture.tsx
@@ -18,7 +18,7 @@ function ProfilePicture({ width, isActive, image }: ProfilePictureProps) {
       style={{ width: width, height: width }}
     >
       {image ? (
-        <Image
+        <img
           src={`${image}`}
           alt="User profile image"
           style={{ objectFit: "cover" }}

--- a/app/_components/SideMenu.tsx
+++ b/app/_components/SideMenu.tsx
@@ -55,7 +55,7 @@ const SideMenu = () => {
           ))}
         </ul>
         <div className="group relative">
-          <Link href="/create">
+          <Link href="/server/create">
             <span className="relative my-2 inline-block overflow-hidden rounded-full bg-gray-500 shadow-md transition-all group-hover:rounded-md">
               <MaterialSymbolsLightAdd
                 width={40}

--- a/app/_components/SideMenu.tsx
+++ b/app/_components/SideMenu.tsx
@@ -1,82 +1,59 @@
-"use client";
 import React from "react";
 import ColumnWrapper from "./wrappers/ColumnWrapper";
-import Link from "next/link";
-import Image from "next/image";
-import diamond from "../../public/icons/diamond.svg";
-import pipeTop from "../../public/icons/pipe-top.svg";
-import pizzaSlice from "../../public/icons/pizza-slice.svg";
 import MaterialSymbolsLight3p from "../../public/icons/MaterialSymbolsLight3p";
-import MaterialSymbolsLightAdd from "../../public/icons/MaterialSymbolsLightAdd";
-import logOut from "../../actions/logout";
-import MaterialSymbolsLightLoginOutlineRounded from "../../public/icons/MaterialSymbolsLightLoginOutlineRounded";
-interface Server {
-  id: number;
-  name: string;
-  icon: string;
+import { twMerge } from "tailwind-merge";
+import MenuIconServer from "./menu_items/MenuIconServer";
+import MenuButtonLogout from "./menu_items/MenuButtonLogout";
+import MenuButtonNewServer from "./menu_items/MenuButtonNewServer";
+import { auth } from "../../auth";
+import { getUserServers } from "../../prisma/services/userService";
+import FeedbackCard from "./FeedbackCard";
+import { Session } from "next-auth";
+
+//global types file doesn't like imports so we're declaring this here for now
+declare global {
+  interface ExtendedSession extends Session {
+    userId: string;
+  }
 }
 
-const SideMenu = () => {
-  const servers: Server[] = [
-    { id: 1, name: "Mansen Maakarit", icon: diamond },
-    { id: 2, name: "Don't Come Here", icon: pipeTop },
-    { id: 3, name: "Pizza", icon: pizzaSlice },
-    // Add more servers as needed
-  ];
+const SideMenu = async ({ className }: { className?: string }) => {
+  const session = await auth();
 
-  const handleLogout = () => {
-    logOut();
-  };
+  if (!session || !(session as ExtendedSession).userId)
+    return <FeedbackCard type="error" message="Something went wrong!" />;
+
+  const servers = await getUserServers((session as ExtendedSession).userId, {
+    id: true,
+    server_name: true,
+  });
+
+  console.log(servers);
+
+  if (typeof servers === "string")
+    return <FeedbackCard type="error" message="Something went wrong!" />;
+
   return (
     <nav className="relative">
       <ColumnWrapper
         align="items-center"
-        className="bg-color-dark sticky left-0 top-0 mr-2 h-screen border-r-2 border-gray-600"
+        className={twMerge(
+          "bg-color-dark sticky left-0 top-0 mr-2 h-screen border-r-2 border-gray-600",
+          className ? className : "",
+        )}
       >
         <MaterialSymbolsLight3p width={40} height={40} />
         <ul>
           {servers.map((server) => (
             <li key={server.id}>
-              <Link href={`/server/${server.id}`}>
-                <div className="group relative">
-                  <span className="relative my-2 inline-block overflow-hidden rounded-full bg-gray-500 shadow-md transition-all group-hover:rounded-md">
-                    <Image
-                      src={server.icon}
-                      alt={server.name}
-                      className="h-12 w-12 cursor-pointer rounded-full transition-all group-hover:rounded-md"
-                    />
-                  </span>
-                  <span className="absolute bottom-1 left-20 -translate-x-1/2 transform rounded-md bg-black px-2 py-1 text-center text-white opacity-0 transition-opacity group-hover:opacity-100">
-                    {server.name}
-                  </span>
-                </div>
-              </Link>
+              <MenuIconServer server={server} />
             </li>
           ))}
         </ul>
         <div className="group relative">
-          <Link href="/server/create">
-            <span className="relative my-2 inline-block overflow-hidden rounded-full bg-gray-500 shadow-md transition-all group-hover:rounded-md">
-              <MaterialSymbolsLightAdd
-                width={40}
-                height={40}
-                className="h-12 w-12 cursor-pointer rounded-full transition-transform hover:rotate-180"
-              />
-            </span>
-            <span className="absolute bottom-1 left-20 -translate-x-1/2 transform rounded-md bg-black px-2 py-1 text-center text-white opacity-0 transition-opacity group-hover:opacity-100">
-              Add server
-            </span>
-          </Link>
+          <MenuButtonNewServer />
         </div>
-        <button
-          onClick={() => handleLogout()}
-          className="group relative mt-auto"
-        >
-          <MaterialSymbolsLightLoginOutlineRounded className="h-12 w-12 cursor-pointer rounded-full p-1 hover:scale-110" />
-          <span className="absolute bottom-1 left-20 -translate-x-1/2 transform rounded-md bg-black px-2 py-1 text-center text-white opacity-0 transition-opacity group-hover:opacity-100">
-            Logout
-          </span>
-        </button>
+        <MenuButtonLogout />
       </ColumnWrapper>
     </nav>
   );

--- a/app/_components/SideMenu.tsx
+++ b/app/_components/SideMenu.tsx
@@ -38,7 +38,7 @@ const SideMenu = async ({ className }: { className?: string }) => {
       <ColumnWrapper
         align="items-center"
         className={twMerge(
-          "bg-color-dark sticky left-0 top-0 mr-2 h-screen border-r-2 border-gray-600",
+          "bg-color-dark sticky left-0 top-0 z-[99] mr-2 h-screen border-r-2 border-gray-600",
           className ? className : "",
         )}
       >

--- a/app/_components/inputs/RadioGroup.tsx
+++ b/app/_components/inputs/RadioGroup.tsx
@@ -11,7 +11,7 @@ type RadioGroupProps = {
   >;
   className?: string;
   labelStyle?: string;
-  selectedColour?: string; //css class
+  radioStyle?: { radioBg: string; selectedColour?: string; radioSize?: string };
   required?: boolean;
 };
 
@@ -22,13 +22,13 @@ export default function RadioGroup({
   setSelected,
   className,
   labelStyle,
-  selectedColour,
+  radioStyle,
 }: RadioGroupProps) {
   const [isInvalid, setIsInvalid] = useState(false);
 
   return (
     <div className={twMerge("flex", className)}>
-      {values.map((value, index) => (
+      {values.map((value) => (
         <RadioInput
           key={groupName + value}
           name={groupName}
@@ -38,7 +38,7 @@ export default function RadioGroup({
           setIsInvalid={setIsInvalid}
           className={className}
           labelStyle={labelStyle}
-          selectedColour={selectedColour}
+          radioStyle={radioStyle}
         />
       ))}
       {isInvalid && (

--- a/app/_components/inputs/RadioInput.tsx
+++ b/app/_components/inputs/RadioInput.tsx
@@ -8,7 +8,7 @@ interface RadioInputProps
     HTMLInputElement
   > {
   labelStyle?: string; //css classes
-  selectedColour?: string; //css class
+  radioStyle?: { radioBg: string; selectedColour?: string; radioSize?: string };
   selected: string | number | readonly string[] | undefined;
   setSelected: React.Dispatch<
     React.SetStateAction<string | number | readonly string[] | undefined>
@@ -20,21 +20,26 @@ export default function RadioInput({
   name,
   value,
   labelStyle,
-  selectedColour,
+  radioStyle,
   selected,
   setSelected,
   setIsInvalid,
   ...rest
 }: RadioInputProps) {
   return (
-    <label htmlFor={name + "-" + value}>
+    <label htmlFor={name + "-" + value} className="rounded-lg">
       <RowWrapper>
         <span className={twMerge("flex-grow-1", labelStyle && labelStyle)}>
           {value}
         </span>
         <div
+          style={{
+            width: radioStyle?.radioSize || "1rem",
+            height: radioStyle?.radioSize || "1rem",
+          }}
           className={twMerge(
-            "mx-2 h-4 w-4 flex-shrink-0 rounded-full border border-black50 bg-opacity-0",
+            "mx-2 flex-shrink-0 rounded-full border border-black50 bg-transparent",
+            radioStyle?.radioBg ? radioStyle.radioBg : "",
           )}
         >
           <svg
@@ -43,9 +48,10 @@ export default function RadioInput({
             viewBox="0 0 16 16"
             className={twMerge(
               "fill-transparent transition-all duration-100 ease-in-out",
-
               selected === value &&
-                (selectedColour ? selectedColour : "fill-primary"),
+                (radioStyle?.selectedColour
+                  ? radioStyle?.selectedColour
+                  : "fill-primary"),
             )}
           >
             <circle r={6} cx={8} cy={8} />

--- a/app/_components/menu_items/MenuButtonLogout.tsx
+++ b/app/_components/menu_items/MenuButtonLogout.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import logOut from "../../../actions/logout";
+import MaterialSymbolsLightLoginOutlineRounded from "../../../public/icons/MaterialSymbolsLightLoginOutlineRounded";
+
+export default function MenuButtonLogout() {
+  const handleLogout = () => {
+    logOut();
+  };
+  return (
+    <button onClick={() => handleLogout()} className="group relative mt-auto">
+      <MaterialSymbolsLightLoginOutlineRounded className="h-12 w-12 cursor-pointer rounded-full p-1 hover:scale-110" />
+      <span className="absolute bottom-1 left-20 -translate-x-1/2 transform rounded-md bg-black px-2 py-1 text-center text-white opacity-0 transition-opacity group-hover:opacity-100">
+        Logout
+      </span>
+    </button>
+  );
+}

--- a/app/_components/menu_items/MenuButtonNewServer.tsx
+++ b/app/_components/menu_items/MenuButtonNewServer.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import Link from "next/link";
+import MaterialSymbolsLightAdd from "../../../public/icons/MaterialSymbolsLightAdd";
+
+export default function MenuButtonNewServer() {
+  return (
+    <Link href="/server/create">
+      <span className="relative my-2 inline-block overflow-hidden rounded-full bg-gray-500 shadow-md transition-all group-hover:rounded-md">
+        <MaterialSymbolsLightAdd
+          width={40}
+          height={40}
+          className="h-12 w-12 cursor-pointer rounded-full transition-transform hover:rotate-180"
+        />
+      </span>
+      <span className="absolute bottom-1 left-20 -translate-x-1/2 transform rounded-md bg-black px-2 py-1 text-center text-white opacity-0 transition-opacity group-hover:opacity-100">
+        Add server
+      </span>
+    </Link>
+  );
+}

--- a/app/_components/menu_items/MenuIconServer.tsx
+++ b/app/_components/menu_items/MenuIconServer.tsx
@@ -1,0 +1,29 @@
+"use client";
+import Link from "next/link";
+
+type Server = {
+  id: string;
+  server_name: string;
+  icon?: string;
+};
+
+export default function MenuIconServer({ server }: { server: Server }) {
+  return (
+    <Link href={`/server/${server.id}`}>
+      <div className="group relative">
+        <span className="relative my-2 inline-block h-12 w-12 cursor-pointer overflow-hidden rounded-full bg-gray-500 shadow-md transition-all group-hover:rounded-md">
+          {server.icon && (
+            <img
+              src={server.icon}
+              alt={server.server_name}
+              className="rounded-full object-cover transition-all group-hover:rounded-md"
+            />
+          )}
+        </span>
+        <span className="absolute bottom-1 left-20 -translate-x-1/2 transform rounded-md bg-black px-2 py-1 text-center text-white opacity-0 transition-opacity group-hover:opacity-100">
+          {server.server_name}
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/app/_components/wrappers/ColumnWrapper.tsx
+++ b/app/_components/wrappers/ColumnWrapper.tsx
@@ -10,6 +10,7 @@ interface ColumnWrapperProps
   justify?: string; //tailwind classes for justifying content/items
   className?: string;
   refObject?: React.RefObject<HTMLDivElement>;
+  mode?: "section" | "div"; //section
 }
 
 export default function ColumnWrapper({
@@ -18,8 +19,25 @@ export default function ColumnWrapper({
   className,
   children,
   refObject,
+  mode,
   ...rest
 }: ColumnWrapperProps) {
+  if (mode && mode === "section")
+    return (
+      <section
+        className={twMerge(
+          "flex flex-col content-center items-center gap-2 p-2",
+          align && align,
+          justify && justify,
+          className && className,
+        )}
+        ref={refObject}
+        {...rest}
+      >
+        {children}
+      </section>
+    );
+
   return (
     <div
       className={twMerge(

--- a/app/server/[...serverId]/layout.tsx
+++ b/app/server/[...serverId]/layout.tsx
@@ -1,0 +1,71 @@
+import { Params } from "next/dist/shared/lib/router/utils/route-matcher";
+import ColumnWrapper from "../../_components/wrappers/ColumnWrapper";
+import {
+  getServerData,
+  getServerMembers,
+} from "../../../prisma/services/serverService";
+import RowWrapper from "../../_components/wrappers/RowWrapper";
+import FeedbackCard from "../../_components/FeedbackCard";
+import UserInfo from "../../_components/UserInfo";
+
+export default async function ServerLayout({
+  params,
+  children,
+}: {
+  params: Params;
+  children: React.ReactNode;
+}) {
+  const id = params.serverId[0];
+
+  const server = await getServerData(id);
+  const members = await getServerMembers(id);
+
+  if (
+    !server ||
+    typeof server === "string" ||
+    !members ||
+    typeof members === "string"
+  )
+    return (
+      <div className="flex-grow">
+        <FeedbackCard type="error" message="Something went wrong!" />
+      </div>
+    );
+
+  const admin = members.filter((item) => item.role === "admin")[0];
+
+  return (
+    <div className="flex flex-grow">
+      <ColumnWrapper
+        mode="section"
+        id="server-inner-nav"
+        className="sticky mr-2 h-full border-r border-r-black50 p-0 md:max-w-[15%]"
+      >
+        <RowWrapper className="border-b border-black50 px-2 pt-1">
+          <h5 className="text-wrap">{server.server_name}</h5>
+        </RowWrapper>
+      </ColumnWrapper>
+      {children}
+      <ColumnWrapper
+        mode="section"
+        id="server-members-nav"
+        className="bg-black"
+      >
+        <ColumnWrapper className="sticky h-full">
+          <h5>Admin</h5>
+          <UserInfo
+            username={admin.user.username || ""}
+            screen_name={
+              admin.nickname
+                ? admin.nickname
+                : admin.user.screen_name || admin.user.username
+            }
+            image={admin.icon ? admin.icon : admin.user.profile_image || ""}
+            isActive={false}
+            width={40}
+          />
+        </ColumnWrapper>
+      </ColumnWrapper>
+    </div>
+  );
+}

--- a/app/server/[...serverId]/loading.tsx
+++ b/app/server/[...serverId]/loading.tsx
@@ -1,0 +1,18 @@
+import ColumnWrapper from "../../_components/wrappers/ColumnWrapper";
+import Main from "../../_components/wrappers/PageMain";
+
+export default function ServerHomeSuspense() {
+  return (
+    <div className="flex flex-grow">
+      <ColumnWrapper className="sticky mr-2 h-full w-[15%] border-r border-r-black50 p-0"></ColumnWrapper>
+      <Main></Main>
+      <ColumnWrapper
+        mode="section"
+        id="server-members-nav"
+        className="bg-black"
+      >
+        <ColumnWrapper className="sticky h-full w-[10%]"></ColumnWrapper>
+      </ColumnWrapper>
+    </div>
+  );
+}

--- a/app/server/[...serverId]/page.tsx
+++ b/app/server/[...serverId]/page.tsx
@@ -1,0 +1,20 @@
+import { Params } from "next/dist/shared/lib/router/utils/route-matcher";
+import Main from "../../_components/wrappers/PageMain";
+import { getServerData } from "../../../prisma/services/serverService";
+import FeedbackCard from "../../_components/FeedbackCard";
+
+export default async function ServerHome({ params }: { params: Params }) {
+  const id = params.serverId[0];
+
+  const server = await getServerData(id);
+
+  if (!server || typeof server === "string") {
+    return <FeedbackCard type="error" message="Something went wrong." />;
+  }
+
+  return (
+    <Main>
+      <h1>Hewwo</h1>
+    </Main>
+  );
+}

--- a/app/server/create/page.tsx
+++ b/app/server/create/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import Link from "next/link";
+import Button from "../../_components/Button";
+import PasswordInput from "../../_components/inputs/PasswordInput";
+import RadioGroup from "../../_components/inputs/RadioGroup";
+import TextAreaInput from "../../_components/inputs/TextAreaInput";
+import TextInput from "../../_components/inputs/TextInput";
+import ToggleInput from "../../_components/inputs/ToggleInput";
+import ColumnWrapper from "../../_components/wrappers/ColumnWrapper";
+import Main from "../../_components/wrappers/PageMain";
+import RowWrapper from "../../_components/wrappers/RowWrapper";
+import { useRef, useState, useTransition } from "react";
+import FeedbackCard from "../../_components/FeedbackCard";
+import createServer from "../../../actions/createServer";
+
+export default function CreateServer() {
+  const [serverName, setServerName] = useState("");
+  const [description, setDescription] = useState("");
+
+  const [isProtected, setIsProtected] = useState(false);
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [explorePermission, setExplorePermission] = useState(false);
+  const [searchPermission, setSearchPermission] = useState(false);
+  const [settingsRightsHolders, setSettingsRightsHolders] = useState("Admin");
+
+  const passwordsMatch = isProtected ? password === confirmPassword : true;
+  const [error, setError] = useState("");
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!passwordsMatch) {
+      setError("Password-protected is selected but passwords don't match.");
+    }
+    if (formRef.current) {
+      const isValid = formRef.current.checkValidity();
+      if (!isValid) {
+        formRef.current.reportValidity();
+      } else {
+        startTransition(() => {
+          createServer({
+            serverName,
+            description,
+            isProtected,
+            password,
+            explorePermission,
+            searchPermission,
+            settingsRightsHolders,
+          });
+        });
+      }
+    }
+  };
+
+  return (
+    <Main className="ml-8">
+      <form ref={formRef} onSubmit={handleSubmit}>
+        <h1>Server Information</h1>
+        <ColumnWrapper
+          mode="section"
+          id="server-information"
+          align="content-start items-start"
+          className="m-0 md:ml-6"
+        >
+          <TextInput
+            className="self-start px-2 py-0 text-xl"
+            placeholder="Server name"
+            value={serverName}
+            onChange={(e) => setServerName(e.target.value)}
+            required
+            endElement={<span className="text-warning">*</span>}
+            disabled={isPending}
+          />
+
+          <h4 className="mt-5">Server icon</h4>
+          <div className="flex h-24 w-24 rounded-full border-[3px] border-dashed border-black50"></div>
+
+          <h4 className="mt-5">Server description</h4>
+          <TextAreaInput
+            borderless
+            className="w-[80%] bg-black25 dark:bg-black75"
+            maxLength={200}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            disabled={isPending}
+          />
+        </ColumnWrapper>
+        <h1>Server security</h1>
+        <ColumnWrapper
+          mode="section"
+          id="server-security"
+          align="content-start items-start"
+          className="m-0 md:ml-6"
+        >
+          <ToggleInput
+            id="password-protection"
+            label="Password-protected server"
+            labelClass="text-md-lg xl:text-lg"
+            onToggle={(checked) => setIsProtected(checked)}
+            disabled={isPending}
+          />
+          <small>Invitees must know the password to join</small>
+          <PasswordInput
+            className="self-start"
+            placeholder="password"
+            required={isProtected}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={isPending}
+          />
+          {!passwordsMatch && (
+            <small className="text-warning">{"Passwords don't match"}</small>
+          )}
+          <PasswordInput
+            className="self-start"
+            placeholder="confirm password"
+            required={isProtected}
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            disabled={isPending}
+          />
+
+          <h4 className="mt-5">Server visibility</h4>
+          <ToggleInput
+            id="server-explore"
+            label="Include server in explore"
+            checked={explorePermission}
+            onToggle={(checked) => setExplorePermission(checked)}
+            disabled={isPending}
+          />
+          <ToggleInput
+            id="server-search"
+            label="Include server in search results"
+            checked={searchPermission}
+            onToggle={(checked) => setSearchPermission(checked)}
+            disabled={isPending}
+          />
+
+          <h4 className="mt-5">Who can customise server settings</h4>
+          <RadioGroup
+            groupName="settings-rights-holders"
+            values={["Admin", "Admin and Moderators", "All members"]}
+            selected={settingsRightsHolders}
+            radioStyle={{
+              radioBg: "bg-white",
+              selectedColour: "fill-black75",
+              radioSize: "1.85rem",
+            }}
+            className="w-[60%] flex-col gap-4 [&>*:nth-child(1)]:bg-[#5DA364] [&>*:nth-child(2)]:bg-[#B8AF5F] [&>*:nth-child(3)]:bg-[#9B3F3F]"
+            labelStyle="w-full justify-between px-4 py-2 text-md-lg xl:text-lg"
+            setSelected={(s) => {
+              setSettingsRightsHolders(s!.toString());
+            }}
+          />
+        </ColumnWrapper>
+        <RowWrapper justify="justify-between" className="my-8 w-[69%] pr-8">
+          <Button className="btn-primary">Create</Button>
+          <Link href={"/"}>
+            <Button className="btn-secondary">Cancel</Button>
+          </Link>
+        </RowWrapper>
+      </form>
+      {error !== "" && <FeedbackCard type="error" message={error} />}
+    </Main>
+  );
+}

--- a/app/server/layout.tsx
+++ b/app/server/layout.tsx
@@ -9,7 +9,7 @@ export default function ServerLayout({
     <div className="flex flex-col">
       {/*prep for top menu*/}
       <div className="flex">
-        <SideMenu />
+        <SideMenu className="m-0" />
         {children}
       </div>
     </div>

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -35,4 +35,18 @@ export default {
       },
     }),
   ],
+  callbacks: {
+    jwt: async ({ token, user }) => {
+      if (user?.id) {
+        token.user_id = user.id;
+      }
+
+      return token;
+    },
+    session: async ({ session, token }) => {
+      session.userId = String(token.user_id);
+
+      return session;
+    },
+  },
 } satisfies NextAuthConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,7 @@ model User {
   created_at              DateTime                  @default(now())
   screen_name             String?
   timezone                String?
+  share_timezone          Boolean?
   person_description      String?
   profile_image           String?
   server_members          ServerMember[]
@@ -57,9 +58,21 @@ model Server {
   gameboard      String?
   created_at     DateTime       @default(now())
   description    String?
+  config         ServerConfig[]
   server_members ServerMember[]
   channels       Channel[]
   characters     Character[]
+}
+
+model ServerConfig {
+  id                  Int     @id @default(autoincrement())
+  server_id           String  @unique
+  config_permission   String
+  protected           Boolean?
+  password_hash       String?
+  explorable          Boolean?
+  searchable          Boolean?
+  server              Server @relation(fields: [server_id], references: [id])
 }
 
 model ServerMember {

--- a/prisma/services/serverService.ts
+++ b/prisma/services/serverService.ts
@@ -1,0 +1,83 @@
+import { db } from "../db";
+
+export const createServerEntry = async (data: {
+  server_name: string;
+  description?: string;
+}) => {
+  try {
+    const server = await db.server.create({ data });
+    return server;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+export const createServerConfig = async (data: {
+  server_id: string;
+  config_permission: string;
+  protected?: boolean;
+  password_hash?: string;
+  explorable?: boolean;
+  searchable?: boolean;
+}) => {
+  try {
+    const serverConfig = await db.serverConfig.create({ data });
+    return serverConfig;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+export const createServerMember = async (data: {
+  server_id: string;
+  member_id: string;
+  role: string;
+}) => {
+  try {
+    const serverMember = await db.serverMember.create({ data });
+    return serverMember;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+export const getServerData = async (id: string) => {
+  try {
+    const server = await db.server.findUnique({ where: { id: id } });
+    return server;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+export const getServerConfig = async (id: string) => {
+  try {
+    const config = await db.serverConfig.findUnique({
+      where: { server_id: id },
+    });
+    return config;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+export const getServerMembers = async (id: string) => {
+  try {
+    const members = await db.serverMember.findMany({
+      where: { server_id: id },
+      include: {
+        user: {
+          select: {
+            username: true,
+            profile_image: true,
+            screen_name: true,
+            timezone: true,
+          },
+        },
+      },
+    });
+    return members;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};

--- a/prisma/services/userService.ts
+++ b/prisma/services/userService.ts
@@ -1,11 +1,32 @@
 import { db } from "../db";
 
-export const getUserById = async (id: string) => {
+export const getUserById = async (
+  id: string,
+  select?: { [key: string]: boolean },
+) => {
   try {
     const user = await db.user.findUnique({
       where: {
         id: id,
       },
+      select: select,
+    });
+    return user;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+export const getUsersById = async (
+  ids: string[],
+  select?: { [key: string]: boolean },
+) => {
+  try {
+    const user = await db.user.findMany({
+      where: {
+        id: { in: ids },
+      },
+      select: select,
     });
     return user;
   } catch (e) {
@@ -32,6 +53,23 @@ export const getUserByUsername = async (username: string) => {
       where: {
         username: username,
       },
+    });
+    return user;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+export const getUsersByUsername = async (
+  usernames: string[],
+  select?: { [key: string]: boolean },
+) => {
+  try {
+    const user = await db.user.findMany({
+      where: {
+        username: { in: usernames },
+      },
+      select: select,
     });
     return user;
   } catch (e) {
@@ -76,6 +114,31 @@ export const updateUser = async (
     });
 
     return updatedUser;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+export const getUserServers = async (
+  userId: string,
+  select?: { [key: string]: boolean },
+) => {
+  try {
+    const memberIn = await db.serverMember.findMany({
+      where: { member_id: userId },
+    });
+    const serverIds = memberIn.map((item) => {
+      return item.server_id;
+    });
+
+    const servers = await db.server.findMany({
+      where: {
+        id: { in: serverIds },
+      },
+      select: select,
+    });
+
+    return servers;
   } catch (e) {
     return (e as Error).message;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
This PR adds the functionality for creating new servers and accessing user's servers

- New ServerConfig table in Prisma schema
- Additions to User table in Prisma schema
- New service functions related to creating and fetching servers, server configs and server members
- New service functions to fetch multiple users with arrays of ids or usernames
- New service function to fetch all servers user is a member of
- New optional select props for data-fetching functions to declare which properties are fetched
- userId as part of session
- New global type ExtendedSession to accommodate userId (declared in _components/SideMenu for the time being to allow import of Session interface from next-auth)
- New prop "mode" in column wrapper to enable rendering of either div or section tags
- More customisation for radio inputs