### PR TITLE
Feat/search-and-explore

### DIFF
--- a/actions/login.ts
+++ b/actions/login.ts
@@ -6,7 +6,10 @@ import { signIn } from "../auth";
 import { DEFAULT_LOGIN_REDIRECT } from "../routes";
 import { AuthError } from "next-auth";
 
-export default async function login(values: z.infer<typeof LoginSchema>) {
+export default async function login(
+  values: z.infer<typeof LoginSchema>,
+  redirectPath?: string,
+) {
   const validatedFields = LoginSchema.safeParse(values);
 
   if (!validatedFields.success) {
@@ -19,7 +22,7 @@ export default async function login(values: z.infer<typeof LoginSchema>) {
     await signIn("credentials", {
       username,
       password,
-      redirectTo: DEFAULT_LOGIN_REDIRECT,
+      redirectTo: redirectPath || DEFAULT_LOGIN_REDIRECT,
     });
   } catch (e) {
     if (e instanceof AuthError) {

--- a/actions/login.ts
+++ b/actions/login.ts
@@ -5,6 +5,8 @@ import { LoginSchema } from "../validation-schemas";
 import { signIn } from "../auth";
 import { DEFAULT_LOGIN_REDIRECT } from "../routes";
 import { AuthError } from "next-auth";
+import { getUserByUsername } from "../prisma/services/userService";
+import * as bcrypt from "bcryptjs";
 
 export default async function login(
   values: z.infer<typeof LoginSchema>,
@@ -17,6 +19,15 @@ export default async function login(
   }
 
   const { username, password } = validatedFields.data;
+
+  //need these checks for correct error display behaviour in production
+  const user = await getUserByUsername(username);
+
+  if (!user) return { error: "Invalid username or password." };
+  if (typeof user === "string") return { error: "Something went wrong." };
+
+  const passwordsMatch = await bcrypt.compare(password, user.password_hash);
+  if (!passwordsMatch) return { error: "Invalid username or password." };
 
   try {
     await signIn("credentials", {

--- a/actions/registerAccount.ts
+++ b/actions/registerAccount.ts
@@ -22,8 +22,6 @@ export default async function registerAccount(
 
   const passwordHash = await bcrypt.hash(password, 10);
 
-  console.log(passwordHash);
-
   const existingEmail = await getUserByEmail(email);
 
   if (existingEmail) return { error: "Email already in use." };
@@ -41,5 +39,5 @@ export default async function registerAccount(
   if (typeof newUser === "string")
     return { error: "Something went wrong. Please try again." };
 
-  return { success: "Verification email sent." };
+  return { username: newUser.username };
 }

--- a/actions/serverMemberManagement/joinServer.ts
+++ b/actions/serverMemberManagement/joinServer.ts
@@ -40,12 +40,14 @@ export default async function joinServer(
 
   const config = await getServerConfig(invitation.server_id);
 
+  console.log(config);
+
   if (!config || typeof config === "string") return "Something went wrong.";
 
   if (!password && config.protected)
     return "Please provide the password to join this server.";
 
-  if (password && config.password_hash) {
+  if (password && config.protected && config.password_hash) {
     const passwordsMatch = await bcrypt.compare(password, config.password_hash);
     if (!passwordsMatch) return "Wrong password.";
   }
@@ -56,6 +58,7 @@ export default async function joinServer(
       member_id: id,
       role: "member",
     });
+    console.log(member);
 
     if (typeof member === "string") return "Error when trying to join.";
     else {
@@ -65,6 +68,7 @@ export default async function joinServer(
       return member;
     }
   } catch (e) {
+    console.log(e);
     return (e as Error).message;
   }
 }

--- a/app/(auth)/login/loading.tsx
+++ b/app/(auth)/login/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <></>;
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -3,20 +3,57 @@
 import ColumnWrapper from "../../_components/wrappers/ColumnWrapper";
 import Main from "../../_components/wrappers/PageMain";
 import LoginForm from "../../_components/forms/LoginForm";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
+import RegisterForm from "@/app/_components/forms/RegisterForm";
+import Loading from "./loading";
+import FeedbackCard from "@/app/_components/FeedbackCard";
 
 export default function Login() {
+  const srv = useSearchParams().get("srv");
+  const inv = useSearchParams().get("inv");
+
   const router = useRouter();
+
+  const [login, setLogin] = useState(true);
+  const [usernameAutofill, setUsernameAutofill] = useState("");
+  const [success, setSuccess] = useState("");
+
+  function setRedirectPath() {
+    if (srv) return `/server/${srv}`;
+    if (inv) return `/server/join/${inv}`;
+    return "/";
+  }
+
+  const redirectPath = setRedirectPath();
+
   return (
-    <Main className="content-center items-center justify-center text-center">
-      <h1 className="text-accent-gradient">Welcome back!</h1>
-      <ColumnWrapper>
-        <LoginForm
-          goToRegister={() => {
-            router.push("/welcome");
-          }}
-        />
-      </ColumnWrapper>
-    </Main>
+    <Suspense fallback={<Loading />}>
+      <Main className="content-center items-center justify-center text-center">
+        <h1 className="text-accent-gradient">Welcome back!</h1>
+        {srv && <p>Please log in or sign up to access the server.</p>}
+        {inv && <p>Please log in or sign up to respond to the invitation.</p>}
+        <ColumnWrapper>
+          {login ? (
+            <LoginForm
+              usernameAutofill={usernameAutofill}
+              goToRegister={() => setLogin(false)}
+              redirectPath={redirectPath}
+            />
+          ) : (
+            <RegisterForm
+              setUsernameAutofill={setUsernameAutofill}
+              goToLogin={() => {
+                setSuccess(
+                  "Your account has been registered. You can now log in.",
+                );
+                setLogin(true);
+              }}
+            />
+          )}
+          {success && <FeedbackCard type="success" message={success} />}
+        </ColumnWrapper>
+      </Main>
+    </Suspense>
   );
 }

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -3,7 +3,7 @@
 import ColumnWrapper from "../../_components/wrappers/ColumnWrapper";
 import Main from "../../_components/wrappers/PageMain";
 import LoginForm from "../../_components/forms/LoginForm";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { Suspense, useState } from "react";
 import RegisterForm from "@/app/_components/forms/RegisterForm";
 import Loading from "./loading";
@@ -12,8 +12,6 @@ import FeedbackCard from "@/app/_components/FeedbackCard";
 export default function Login() {
   const srv = useSearchParams().get("srv");
   const inv = useSearchParams().get("inv");
-
-  const router = useRouter();
 
   const [login, setLogin] = useState(true);
   const [usernameAutofill, setUsernameAutofill] = useState("");

--- a/app/(user)/layout.tsx
+++ b/app/(user)/layout.tsx
@@ -1,6 +1,5 @@
 import SideMenu from "../_components/SideMenu";
 import SocketWrapper from "../_components/wrappers/SocketWrapper";
-import FeedbackCard from "../_components/FeedbackCard";
 import { auth } from "@/auth";
 
 export default async function LoggedLayout({
@@ -9,8 +8,10 @@ export default async function LoggedLayout({
   children: React.ReactNode;
 }) {
   const session = await auth();
-  if (!session || !(session as ExtendedSession).userId)
-    return <FeedbackCard type="error" message="Something went wrong" />;
+
+  //if public route and no session return just the page without the side bar
+  if (!session) return children;
+
   return (
     <SocketWrapper userId={(session as ExtendedSession).userId}>
       <SideMenu />

--- a/app/(user)/server/[serverId]/_components/serverJoinComponents/NotOpen.tsx
+++ b/app/(user)/server/[serverId]/_components/serverJoinComponents/NotOpen.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import Button from "@/app/_components/Button";
+import Main from "@/app/_components/wrappers/PageMain";
+import { useRouter } from "next/navigation";
+
+export default function NotOpen({ reason }: { reason: string }) {
+  const router = useRouter();
+  return (
+    <Main className="items-center justify-center gap-4">
+      <h1>This server cannot be joined at this time.</h1>
+      <h5>{reason}</h5>
+      <Button
+        onClick={() => router.push("/server/explore")}
+        className="btn-secondary"
+      >
+        Back to Explore
+      </Button>
+    </Main>
+  );
+}

--- a/app/(user)/server/[serverId]/_components/serverJoinComponents/Open.tsx
+++ b/app/(user)/server/[serverId]/_components/serverJoinComponents/Open.tsx
@@ -1,0 +1,80 @@
+"use client";
+import joinServer from "@/actions/serverMemberManagement/joinServer";
+import Button from "@/app/_components/Button";
+import FeedbackCard from "@/app/_components/FeedbackCard";
+import PasswordInput from "@/app/_components/inputs/PasswordInput";
+import Main from "@/app/_components/wrappers/PageMain";
+import RowWrapper from "@/app/_components/wrappers/RowWrapper";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+export default function Open({
+  server_name,
+  needsPassword,
+  invitation_id,
+}: {
+  server_name: string;
+  needsPassword: boolean | null;
+  invitation_id: string;
+}) {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const router = useRouter();
+
+  async function handleJoin() {
+    const result = await joinServer(invitation_id, password);
+    if (typeof result === "string") setError(result);
+    else {
+      router.push(`/server/${result.server_id}`);
+      router.refresh();
+    }
+  }
+  return (
+    <Main className="items-center justify-center gap-4">
+      <h1>Would you like to join {server_name}?</h1>
+      {needsPassword && (
+        <>
+          <h5>This server requires a password to join.</h5>
+          <PasswordInput
+            placeholder="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                startTransition(async () => {
+                  await handleJoin();
+                });
+              }
+            }}
+            disabled={isPending}
+          />
+        </>
+      )}
+      <RowWrapper>
+        <Button
+          onClick={() => {
+            startTransition(async () => {
+              await handleJoin();
+            });
+          }}
+          className="btn-primary"
+          disabled={isPending}
+        >
+          Join
+        </Button>
+        <Button
+          onClick={() => {
+            router.push("/server/explore");
+          }}
+          className="btn-secondary"
+          disabled={isPending}
+        >
+          Back to Explore
+        </Button>
+      </RowWrapper>
+      {error !== "" && <FeedbackCard type="error" message={error} />}
+    </Main>
+  );
+}

--- a/app/(user)/server/[serverId]/_components/serverJoinComponents/ServerJoinPage.tsx
+++ b/app/(user)/server/[serverId]/_components/serverJoinComponents/ServerJoinPage.tsx
@@ -1,0 +1,64 @@
+import FeedbackCard from "@/app/_components/FeedbackCard";
+import { getServerJoinData } from "@/prisma/services/serverService";
+import NotOpen from "./NotOpen";
+import Open from "./Open";
+
+export default async function ServerJoinPage({
+  server_id,
+}: {
+  server_id: string;
+}) {
+  const server = await getServerJoinData(server_id);
+
+  if (!server || typeof server === "string")
+    return <FeedbackCard type="error" message="Something went wrong" />;
+
+  if (
+    !server.config[0].join_permission ||
+    server.config[0].join_permission === "invitation link"
+  )
+    return (
+      <NotOpen reason="Unfortunately this server can only be joined by a direct invitation." />
+    );
+
+  const validUnlimited = server.invitations.filter(
+    (item) => !item.max_uses && new Date(item.expires) > new Date(),
+  );
+
+  if (server.config[0].join_permission === "unlimited invitation")
+    if (validUnlimited.length === 0)
+      return (
+        <NotOpen reason="Unfortunately this server has no open invitations." />
+      );
+    else {
+      return (
+        <Open
+          server_name={server.server_name}
+          needsPassword={server.config[0].protected}
+          invitation_id={validUnlimited[0].id}
+        />
+      );
+    }
+
+  const validLimited = server.invitations.filter(
+    (item) =>
+      item.max_uses &&
+      new Date(item.expires) > new Date() &&
+      item.used_count < item.max_uses,
+  );
+
+  if (validUnlimited.length === 0 && validLimited.length === 0)
+    return (
+      <NotOpen reason="Unfortunately this server has no open invitations." />
+    );
+
+  return (
+    <Open
+      server_name={server.server_name}
+      needsPassword={server.config[0].protected}
+      invitation_id={
+        validUnlimited[0] ? validUnlimited[0].id : validLimited[0].id
+      }
+    />
+  );
+}

--- a/app/(user)/server/[serverId]/layout.tsx
+++ b/app/(user)/server/[serverId]/layout.tsx
@@ -4,7 +4,7 @@ import ServerInnerNav from "./_components/ServerInnerNav";
 import ServerMembersMenu from "./_components/ServerMembersMenu";
 import { auth } from "@/auth";
 import getServerAuth from "@/actions/getServerAuth";
-import { redirect } from "next/navigation";
+import ServerJoinPage from "./_components/serverJoinComponents/ServerJoinPage";
 
 export default async function ServerLayout({
   params,
@@ -16,15 +16,12 @@ export default async function ServerLayout({
   const id = params.serverId;
 
   const session = await auth();
-
-  if (!session) redirect("/welcome");
-
   const serverAuth = await getServerAuth(
     id,
     (session as ExtendedSession).userId,
   );
 
-  if (!serverAuth) redirect("/server");
+  if (!serverAuth) return <ServerJoinPage server_id={id} />;
 
   return (
     <LayoutClientWrapper

--- a/app/(user)/server/_components/ExploreCarousel.tsx
+++ b/app/(user)/server/_components/ExploreCarousel.tsx
@@ -1,0 +1,44 @@
+import ColumnWrapper from "@/app/_components/wrappers/ColumnWrapper";
+import ServerThumb from "./ServerThumb";
+import RowWrapper from "@/app/_components/wrappers/RowWrapper";
+
+type ExploreCarouselProps = {
+  title: string;
+  servers: {
+    id: string;
+    server_name: string;
+    image: string | null;
+    created_at: Date;
+    description: string | null;
+    config: {
+      join_permission: string | null;
+    }[];
+    invitations: {
+      expires: string;
+      max_uses: number | null;
+    }[];
+    server_members: {
+      user: {
+        socket_id: string | null;
+      };
+    }[];
+  }[];
+};
+
+export default async function ExploreCarousel({
+  title,
+  servers,
+}: ExploreCarouselProps) {
+  return (
+    <ColumnWrapper align="content-start items-start w-full">
+      <h3>{title}</h3>
+      <div className="scrollbar-thin scroll-thumb-faint h-[80vh] w-[18rem] overflow-clip overflow-y-auto pt-2 sm:h-[11rem] sm:w-full sm:overflow-x-auto">
+        <RowWrapper breakPoint="sm" className="py-4 sm:px-4 sm:py-0">
+          {servers.map((server) => (
+            <ServerThumb key={server.id} server={server} />
+          ))}
+        </RowWrapper>
+      </div>
+    </ColumnWrapper>
+  );
+}

--- a/app/(user)/server/_components/ExploreSearchNav.tsx
+++ b/app/(user)/server/_components/ExploreSearchNav.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import RowWrapper from "@/app/_components/wrappers/RowWrapper";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { twMerge } from "tailwind-merge";
+
+export default function ExploreSearchNav() {
+  return (
+    <RowWrapper
+      className="mb-4 w-full border-b-[1px] border-black25 py-1 dark:border-black75"
+      justify="justify-evenly"
+    >
+      <ExploreNavLink to="/server/explore" label="Explore" />
+      <ExploreNavLink to="/server/search" label="Search" />
+    </RowWrapper>
+  );
+}
+
+function ExploreNavLink({ to, label }: { to: string; label: string }) {
+  const path = usePathname();
+  console.log(path);
+  const ariaCurrent = to === path ? "page" : undefined;
+  console.log(ariaCurrent);
+  return (
+    <Link
+      className={twMerge(
+        "rounded-lg px-2 py-1",
+        ariaCurrent === "page" && "bg-primary-mid",
+      )}
+      href={`${to}`}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/app/(user)/server/_components/ServerIcon.tsx
+++ b/app/(user)/server/_components/ServerIcon.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+type Server = {
+  id: string;
+  server_name: string;
+  image: string | null;
+};
+
+/**
+ * CLIENT component for server icon in side menu
+ * @param server - server information (id, server_name, image)
+ * @param icon - ReactNode, Icon component. Passed as prop to retain its server-side functionality
+ * @returns JSX element with hover functionality
+ */
+export default function ServerIcon({
+  server,
+  icon,
+}: {
+  server: Server;
+  icon: React.ReactNode;
+}) {
+  return (
+    <Link href={`/server/${server.id}`}>
+      <span className="relative my-2 inline-block h-12 w-12 cursor-pointer overflow-hidden rounded-full bg-black50 shadow-md transition-all group-hover:rounded-md">
+        {server.image && icon}
+      </span>
+    </Link>
+  );
+}

--- a/app/(user)/server/_components/ServerThumb.tsx
+++ b/app/(user)/server/_components/ServerThumb.tsx
@@ -1,0 +1,69 @@
+import Icon from "@/app/_components/Icon";
+import ColumnWrapper from "@/app/_components/wrappers/ColumnWrapper";
+import RowWrapper from "@/app/_components/wrappers/RowWrapper";
+import ServerIcon from "./ServerIcon";
+import Link from "next/link";
+
+type ServerThumbProps = {
+  server: {
+    id: string;
+    server_name: string;
+    image: string | null;
+    created_at: Date;
+    description: string | null;
+    config: {
+      join_permission: string | null;
+    }[];
+    invitations: {
+      expires: string;
+      max_uses: number | null;
+    }[];
+    server_members: {
+      user: {
+        socket_id: string | null;
+      };
+    }[];
+  };
+};
+
+export default function ServerThumb({ server }: ServerThumbProps) {
+  return (
+    <ColumnWrapper className="card-back h-[9rem] w-[16rem] flex-shrink-0 gap-0 rounded-xl px-0 py-1 duration-150 ease-linear hover:-translate-y-[0.5rem]">
+      <RowWrapper
+        className="gap-4"
+        justify="justify-items-start w-full mb-0 h-[45%] pt-2 pl-2"
+      >
+        <ServerIcon
+          server={server}
+          icon={<Icon filename={server.image || ""} alt={server.server_name} />}
+        />
+        <Link href={`/server/${server.id}`}>
+          <h5 className="hover:text-accent-gradient">{server.server_name}</h5>
+        </Link>
+      </RowWrapper>
+      <ColumnWrapper
+        className="m-0 w-[90%] flex-grow p-0"
+        justify="justify-between justify-items-between"
+      >
+        <p className="hover:text-color-default line-clamp-2 w-full text-ellipsis text-wrap break-words text-black50">
+          {server.description}
+        </p>
+        <RowWrapper
+          className="m-0 w-full p-0"
+          justify="justify-evenly justify-items-evenly"
+        >
+          <span className="text-xs text-accent">
+            {
+              server.server_members.filter((member) => member.user.socket_id)
+                .length
+            }{" "}
+            Online
+          </span>{" "}
+          <span className="text-xs">
+            {server.server_members.length} Members
+          </span>
+        </RowWrapper>
+      </ColumnWrapper>
+    </ColumnWrapper>
+  );
+}

--- a/app/(user)/server/explore/page.tsx
+++ b/app/(user)/server/explore/page.tsx
@@ -1,0 +1,14 @@
+import Main from "@/app/_components/wrappers/PageMain";
+import { getNewlyCreated } from "@/prisma/services/exploreServers";
+import ExploreCarousel from "../_components/ExploreCarousel";
+import ExploreSearchNav from "../_components/ExploreSearchNav";
+
+export default async function ServerHub() {
+  const newlyCreated = await getNewlyCreated();
+  return (
+    <Main className="content-start items-start">
+      <ExploreSearchNav />
+      <ExploreCarousel title="New servers" servers={newlyCreated} />
+    </Main>
+  );
+}

--- a/app/(user)/server/join/[invitationId]/_components/InvitationNotValid.tsx
+++ b/app/(user)/server/join/[invitationId]/_components/InvitationNotValid.tsx
@@ -1,10 +1,10 @@
-import ColumnWrapper from "@/app/_components/wrappers/ColumnWrapper";
+import Main from "@/app/_components/wrappers/PageMain";
 
 export default function InvitationNotValid() {
   return (
-    <ColumnWrapper>
+    <Main className="items-center justify-center">
       <h4>Oops!</h4>
       <h5>It looks like that invitation is no longer valid.</h5>
-    </ColumnWrapper>
+    </Main>
   );
 }

--- a/app/(user)/server/join/[invitationId]/_components/NotProtected.tsx
+++ b/app/(user)/server/join/[invitationId]/_components/NotProtected.tsx
@@ -3,7 +3,7 @@
 import joinServer from "@/actions/serverMemberManagement/joinServer";
 import Button from "@/app/_components/Button";
 import FeedbackCard from "@/app/_components/FeedbackCard";
-import ColumnWrapper from "@/app/_components/wrappers/ColumnWrapper";
+import Main from "@/app/_components/wrappers/PageMain";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
@@ -26,7 +26,7 @@ export default function NotProtected({
     }
   }
   return (
-    <ColumnWrapper>
+    <Main className="items-center justify-center">
       <h1>You have been invited to join {serverName}.</h1>
       <Button
         className="btn-primary"
@@ -36,6 +36,6 @@ export default function NotProtected({
         Join
       </Button>
       {error !== "" && <FeedbackCard type="error" message={error} />}
-    </ColumnWrapper>
+    </Main>
   );
 }

--- a/app/(user)/server/join/[invitationId]/_components/PasswordProtected.tsx
+++ b/app/(user)/server/join/[invitationId]/_components/PasswordProtected.tsx
@@ -4,7 +4,7 @@ import joinServer from "@/actions/serverMemberManagement/joinServer";
 import Button from "@/app/_components/Button";
 import FeedbackCard from "@/app/_components/FeedbackCard";
 import PasswordInput from "@/app/_components/inputs/PasswordInput";
-import ColumnWrapper from "@/app/_components/wrappers/ColumnWrapper";
+import Main from "@/app/_components/wrappers/PageMain";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
@@ -31,7 +31,7 @@ export default function PasswordProtected({
   }
 
   return (
-    <ColumnWrapper>
+    <Main className="items-center justify-center">
       <h1>You have been invited to join {serverName}.</h1>
       <h5>This server requires a password.</h5>
       <PasswordInput
@@ -39,6 +39,11 @@ export default function PasswordProtected({
         value={password}
         onChange={(e) => setPassword(e.target.value)}
         disabled={isPending}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            startTransition(async () => await handleJoin());
+          }
+        }}
       />
       <Button
         className="btn-primary"
@@ -48,6 +53,6 @@ export default function PasswordProtected({
         Join
       </Button>
       {error !== "" && <FeedbackCard type="error" message={error} />}
-    </ColumnWrapper>
+    </Main>
   );
 }

--- a/app/(user)/server/join/[invitationId]/page.tsx
+++ b/app/(user)/server/join/[invitationId]/page.tsx
@@ -8,7 +8,7 @@ import { getServerData } from "@/prisma/services/serverService";
 
 export default async function JoinServer({ params }: { params: Params }) {
   const id = params.invitationId;
-  console.log(id);
+
   const invitation = await getInvitationById(id);
 
   if (typeof invitation === "string")

--- a/app/(user)/server/page.ts
+++ b/app/(user)/server/page.ts
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function ServerDefaultRedirect() {
-  return redirect("/server/explore");
-}

--- a/app/(user)/server/page.ts
+++ b/app/(user)/server/page.ts
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function ServerDefaultRedirect() {
+  return redirect("/server/explore");
+}

--- a/app/(user)/server/page.tsx
+++ b/app/(user)/server/page.tsx
@@ -1,8 +1,0 @@
-export default function Home() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <h1>Server</h1>
-    </main>
-  );
-}
-

--- a/app/(user)/server/search/_components/SearchBar.tsx
+++ b/app/(user)/server/search/_components/SearchBar.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import TextInput from "@/app/_components/inputs/TextInput";
+import MaterialSymbolsLightSearchRounded from "@/public/icons/MaterialSymbolsLightSearchRounded";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export default function SearchBar() {
+  const [searchTerm, setSearchTerm] = useState("");
+  const router = useRouter();
+  return (
+    <TextInput
+      value={searchTerm}
+      onChange={(e) => setSearchTerm(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          router.push(`/server/search?q=${searchTerm}`);
+        }
+      }}
+      endElement={
+        <button
+          className="text-default text-xl"
+          onClick={() => {
+            router.push(`/server/search?q=${searchTerm}`);
+          }}
+        >
+          <MaterialSymbolsLightSearchRounded />
+        </button>
+      }
+    />
+  );
+}

--- a/app/(user)/server/search/page.tsx
+++ b/app/(user)/server/search/page.tsx
@@ -1,0 +1,30 @@
+import Main from "@/app/_components/wrappers/PageMain";
+import SearchBar from "./_components/SearchBar";
+import { Params } from "next/dist/shared/lib/router/utils/route-matcher";
+import { getAllBySearchTerm } from "@/prisma/services/searchServers";
+import ServerThumb from "../_components/ServerThumb";
+import ExploreSearchNav from "../_components/ExploreSearchNav";
+
+export default async function ServerSearch({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const searchTerm = searchParams?.q || "";
+
+  const servers = await getAllBySearchTerm(searchTerm.toString());
+  return (
+    <Main>
+      <ExploreSearchNav />
+      <SearchBar />
+      <div className="grid grid-cols-1 justify-items-center px-4 py-2 md:grid-cols-2 lg:grid-cols-3">
+        {servers.length > 0 &&
+          servers.map((server) => (
+            <div key={server.id} className="py-2">
+              <ServerThumb server={server} />
+            </div>
+          ))}
+      </div>
+    </Main>
+  );
+}

--- a/app/_components/forms/LoginForm.tsx
+++ b/app/_components/forms/LoginForm.tsx
@@ -15,29 +15,34 @@ import FeedbackCard from "../FeedbackCard";
 
 type LoginFormProps = {
   goToRegister: () => void;
+  usernameAutofill?: string;
   className?: string;
   title?: boolean;
+  redirectPath?: string;
 };
 /**
  * Reusable login form component.
  * Value validation via zodResolver.
  *
  * @param goToRegister - return type void function that can be used to either alter the state of the page or redirect to a different page
+ * @param usernameAutofill - optional autofill that can be carried over from successful registering
  * @param className - optional additional css classes for section-tag (twMerge - will overwrite component's default tailwind classes as needed)
  * @param title - optional title to be displayed in h2-tags on top of form
  */
 
 export default function LoginForm({
   goToRegister,
+  usernameAutofill,
   className,
   title,
+  redirectPath,
 }: LoginFormProps) {
   const { register, handleSubmit, formState } = useForm<
     z.infer<typeof LoginSchema>
   >({
     resolver: zodResolver(LoginSchema),
     defaultValues: {
-      username: "",
+      username: usernameAutofill || "",
       password: "",
     },
   });
@@ -51,7 +56,7 @@ export default function LoginForm({
         onSubmit={handleSubmit((values: z.infer<typeof LoginSchema>) => {
           setError("");
           startTransition(() => {
-            login(values).then(
+            login(values, redirectPath).then(
               (data) => data && data.error && setError(data.error),
             );
           });

--- a/app/_components/forms/LoginForm.tsx
+++ b/app/_components/forms/LoginForm.tsx
@@ -53,7 +53,8 @@ export default function LoginForm({
   return (
     <section id="login" className={twMerge("text-center", className)}>
       <form
-        onSubmit={handleSubmit((values: z.infer<typeof LoginSchema>) => {
+        onSubmit={handleSubmit((values: z.infer<typeof LoginSchema>, e) => {
+          e?.preventDefault();
           setError("");
           startTransition(() => {
             login(values, redirectPath).then(

--- a/app/_components/forms/LoginForm.tsx
+++ b/app/_components/forms/LoginForm.tsx
@@ -56,10 +56,12 @@ export default function LoginForm({
         onSubmit={handleSubmit((values: z.infer<typeof LoginSchema>, e) => {
           e?.preventDefault();
           setError("");
-          startTransition(() => {
-            login(values, redirectPath).then(
-              (data) => data && data.error && setError(data.error),
-            );
+          startTransition(async () => {
+            const result = await login(values, redirectPath);
+            if (result) {
+              setError(result.error);
+              return;
+            }
           });
         })}
       >

--- a/app/_components/forms/RegisterForm.tsx
+++ b/app/_components/forms/RegisterForm.tsx
@@ -15,6 +15,7 @@ import FeedbackCard from "../FeedbackCard";
 
 type RegisterFormProps = {
   goToLogin: () => void;
+  setUsernameAutofill?: React.Dispatch<React.SetStateAction<string>>;
   className?: string;
   title?: boolean;
 };
@@ -29,6 +30,7 @@ type RegisterFormProps = {
 
 export default function RegisterForm({
   goToLogin,
+  setUsernameAutofill,
   className,
   title,
 }: RegisterFormProps) {
@@ -56,8 +58,16 @@ export default function RegisterForm({
           setSuccess("");
           startTransition(() => {
             registerAccount(values).then((data) => {
-              data.error && setError(data.error);
-              data.success && setSuccess(data.success);
+              if (data.error) {
+                setError(data.error);
+                return;
+              }
+              if (setUsernameAutofill) {
+                setUsernameAutofill(data.username!);
+                goToLogin();
+              } else {
+                setSuccess("Verification email sent.");
+              }
             });
           });
         })}

--- a/app/_components/forms/RegisterForm.tsx
+++ b/app/_components/forms/RegisterForm.tsx
@@ -53,7 +53,8 @@ export default function RegisterForm({
   return (
     <section id="register" className={twMerge("text-center", className)}>
       <form
-        onSubmit={handleSubmit((values: z.infer<typeof RegisterSchema>) => {
+        onSubmit={handleSubmit((values: z.infer<typeof RegisterSchema>, e) => {
+          e?.preventDefault();
           setError("");
           setSuccess("");
           startTransition(() => {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,21 +1,56 @@
 import authConfig from "./auth.config";
 import NextAuth from "next-auth";
-import { DEFAULT_LOGIN_REDIRECT, authRoutes, apiAuthPrefix } from "./routes";
+import {
+  DEFAULT_LOGIN_REDIRECT,
+  authRoutes,
+  apiAuthPrefix,
+  serverPublicRoutes,
+} from "./routes";
 
 const { auth } = NextAuth(authConfig);
 
 export default auth((req) => {
   const { nextUrl } = req;
-  const isLoggedIn = !!req.auth;
 
+  //redirect from /server to /server/explore
+  const isServerRedirectPath = nextUrl.pathname === "/server";
+  if (isServerRedirectPath)
+    return Response.redirect(new URL("/server/explore", nextUrl));
+
+  //allow anyone to access APIAuthRoutes
   const isAPIAuthRoute = nextUrl.pathname.startsWith(apiAuthPrefix);
   if (isAPIAuthRoute) return;
 
+  //allow anyone to access server explore and search routes
+  const isServerPublicRoute = serverPublicRoutes.includes(nextUrl.pathname);
+
+  if (isServerPublicRoute) {
+    return;
+  }
+
+  const isLoggedIn = !!req.auth;
+
+  const isServerPrivateRoute = nextUrl.pathname.includes("server/");
+
+  //if user tries to access server or invitation without logging in redirect with invitation or server id in query to facilitate post-login redirection
+  if (isServerPrivateRoute && !isLoggedIn) {
+    if (nextUrl.pathname.includes("join")) {
+      const invId = nextUrl.pathname.split("/")[3];
+      return Response.redirect(new URL(`/login?inv=${invId}`, nextUrl));
+    }
+
+    const srvId = nextUrl.pathname.split("/")[2];
+    return Response.redirect(new URL(`/login?srv=${srvId}`, nextUrl));
+  }
+
   const isAuthRoute = authRoutes.includes(nextUrl.pathname);
+
   if (isAuthRoute) {
+    //prevent logged-in users from accessing register and login pages
     if (isLoggedIn) {
       return Response.redirect(new URL(DEFAULT_LOGIN_REDIRECT, nextUrl));
     }
+    //prevent visitors from accessing pages meant for logged-in users
   } else if (!isLoggedIn)
     return Response.redirect(new URL("/welcome", nextUrl));
 

--- a/prisma/services/exploreServers.ts
+++ b/prisma/services/exploreServers.ts
@@ -1,0 +1,36 @@
+import { db } from "../db";
+
+export async function getNewlyCreated() {
+  const limit = subtractDays(new Date(Date.now()).toISOString(), 14);
+  //get all servers created within the past 14 days
+  const servers = await db.server.findMany({
+    where: {
+      created_at: { gte: limit },
+      AND: {
+        config: {
+          some: {
+            explorable: true,
+          },
+        },
+      },
+    },
+    select: {
+      id: true,
+      server_name: true,
+      created_at: true,
+      description: true,
+      image: true,
+      config: { select: { join_permission: true } },
+      invitations: { select: { max_uses: true, expires: true } },
+      server_members: { select: { user: { select: { socket_id: true } } } },
+    },
+  });
+  console.log(servers);
+  return servers;
+}
+
+function subtractDays(date: string, days: number) {
+  var result = new Date(date);
+  result.setDate(result.getDate() - days);
+  return result;
+}

--- a/prisma/services/searchServers.ts
+++ b/prisma/services/searchServers.ts
@@ -1,0 +1,31 @@
+import { db } from "../db";
+
+export async function getAllBySearchTerm(searchTerm: string) {
+  const servers = await db.server.findMany({
+    where: {
+      OR: [
+        { server_name: { contains: searchTerm } },
+        { description: { contains: searchTerm } },
+      ],
+      AND: {
+        config: {
+          some: {
+            searchable: true,
+          },
+        },
+      },
+    },
+    select: {
+      id: true,
+      server_name: true,
+      created_at: true,
+      description: true,
+      image: true,
+      config: { select: { join_permission: true } },
+      invitations: { select: { max_uses: true, expires: true } },
+      server_members: { select: { user: { select: { socket_id: true } } } },
+    },
+  });
+  console.log(servers);
+  return servers;
+}

--- a/prisma/services/serverService.ts
+++ b/prisma/services/serverService.ts
@@ -44,12 +44,33 @@ export const createServerMember = async (data: {
 
 export const getServerData = async (
   id: string,
-  select?: { [key: string]: boolean },
+  select?: {
+    [key: string]: boolean;
+  },
 ) => {
   try {
     const server = await db.server.findUnique({
       where: { id: id },
       select: select,
+    });
+    return server;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+export const getServerJoinData = async (id: string) => {
+  try {
+    const server = await db.server.findUnique({
+      where: { id: id },
+      select: {
+        id: true,
+        server_name: true,
+        config: { select: { join_permission: true, protected: true } },
+        invitations: {
+          select: { id: true, used_count: true, max_uses: true, expires: true },
+        },
+      },
     });
     return server;
   } catch (e) {

--- a/public/icons/MaterialSymbolsLightSearchRounded.tsx
+++ b/public/icons/MaterialSymbolsLightSearchRounded.tsx
@@ -1,0 +1,8 @@
+import React, { SVGProps } from 'react'
+
+export function MaterialSymbolsLightSearchRounded(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" {...props}><path fill="currentColor" d="M9.538 15.23q-2.398 0-4.064-1.666T3.808 9.5q0-2.398 1.666-4.064t4.064-1.667q2.399 0 4.065 1.667q1.666 1.666 1.666 4.064q0 1.042-.369 2.017q-.37.975-.97 1.668l5.908 5.907q.14.14.15.345q.01.203-.15.363q-.16.16-.353.16q-.195 0-.354-.16l-5.908-5.908q-.75.639-1.725.989q-.975.35-1.96.35m0-1q1.99 0 3.361-1.37q1.37-1.37 1.37-3.361q0-1.99-1.37-3.36q-1.37-1.37-3.36-1.37q-1.99 0-3.361 1.37q-1.37 1.37-1.37 3.36q0 1.99 1.37 3.36q1.37 1.37 3.36 1.37"></path></svg>
+  )
+}
+export default MaterialSymbolsLightSearchRounded

--- a/routes.ts
+++ b/routes.ts
@@ -1,3 +1,5 @@
+export const serverPublicRoutes = ["/server/explore", "/server/search"];
+
 /**
  * Routes that can be accessed without logging in
  * @type {string[]}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,6 +6,8 @@
   --primary-to-accent: linear-gradient(70deg, #65ae45 0%, #ffd700 100%);
   --primary-to-light: linear-gradient(70deg, #65ae45 0%, #d9ebd1 100%);
   --primary-to-dark: linear-gradient(70deg, #65ae45 0%, #314029 100%);
+  --dark-mode-gradient: linear-gradient(179deg, #575558 0%, #403e42 70%);
+  --light-mode-gradient: linear-gradient(180deg, #c7c6c7 0%, #fff 1%);
 }
 
 @layer base {
@@ -133,12 +135,16 @@
 }
 
 .scrollbar-thin::-webkit-scrollbar-thumb {
-  background-color: #c7c6c7;
+  background-color: #8f8d8f;
   border-radius: 0.5rem;
 }
 
 .scrollbar-thin::-webkit-scrollbar-corner {
   background-color: transparent;
+}
+
+.scroll-thumb-faint::-webkit-scrollbar-thumb {
+  background-color: #c7c6c7;
 }
 
 input:-internal-autofill-selected,
@@ -150,6 +156,14 @@ textarea:-webkit-autofill {
   -webkit-text-fill-color: #1f1c20 !important;
   color: inherit !important;
   transition: background-color 5000s ease-in-out 0s;
+}
+
+.card-back {
+  background: var(--light-mode-gradient);
+  background-color: #c7c6c7;
+  box-shadow:
+    #8f8d8f 0px 1px 0px,
+    #8f8d8f 0px 2px 4px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -166,5 +180,17 @@ textarea:-webkit-autofill {
   .scrollbar-thin::-webkit-scrollbar-thumb {
     background-color: white;
     border-radius: 0.5rem;
+  }
+
+  .scroll-thumb-faint::-webkit-scrollbar-thumb {
+    background-color: #575558;
+  }
+
+  .card-back {
+    background: var(--dark-mode-gradient);
+    background-color: #575558;
+    box-shadow:
+      #1f1c20 0px 1px 0px,
+      #1f1c20 0px 2px 4px;
   }
 }


### PR DESCRIPTION
This PR adds pages for exploring and searching servers as well as rerouting behaviour for visitors to log in and return to the server or invitation they tried to access. Servers now offer non-members the option to join provided that the join permission config has been set to allow that, and that valid invitations corresponding to the permission level exist.

Additions:
- pages for search and explore
- server thumbnail
- service functions for getting servers created within the past 14 days and servers with search term in either the name or description
- Page and logic to display whether a non-member can join a server or not

Changes:
- Fixed issue in which login errors did not display properly in production build
- Altered rerouting behaviour so that search and explore are accessible by any one
- Altered (user) and server layout displays to handle visitors and non-members
- Added rerouting back to server/invitation from login page
- Added register form to login page
- Added optional reroute path parameter for login function